### PR TITLE
feat(middleware): add middleware inside routeHandlerBuilder

### DIFF
--- a/src/createSafeRoute.ts
+++ b/src/createSafeRoute.ts
@@ -1,5 +1,8 @@
 import { RouteHandlerBuilder } from './routeHandlerBuilder';
+import { HandlerServerErrorFn } from './types';
 
-export function createSafeRoute(): RouteHandlerBuilder {
-  return new RouteHandlerBuilder();
+export function createSafeRoute(params?: { handleServerError?: HandlerServerErrorFn }): RouteHandlerBuilder {
+  return new RouteHandlerBuilder({
+    handleServerError: params?.handleServerError,
+  });
 }

--- a/src/routeHandlerBuilder.test.ts
+++ b/src/routeHandlerBuilder.test.ts
@@ -227,4 +227,62 @@ describe('combined validation', () => {
     expect(response.status).toBe(400);
     expect(data.message).toBe('Invalid body');
   });
+
+  it('should execute middleware and add context properties', async () => {
+    const middleware = async () => {
+      return { user: { id: 'user-123', role: 'admin' } };
+    };
+
+    const GET = createSafeRoute()
+      .use(middleware)
+      .params(paramsSchema)
+      .handler((request, context) => {
+        const { id } = context.params;
+        const { user } = context.data;
+
+        return Response.json({ id, user }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: { id: '550e8400-e29b-41d4-a716-446655440000' } });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      user: { id: 'user-123', role: 'admin' },
+    });
+  });
+
+  it('should execute multiple middlewares and merge context properties', async () => {
+    const middleware1 = async () => {
+      return { user: { id: 'user-123' } };
+    };
+
+    const middleware2 = async () => {
+      return { permissions: ['read', 'write'] };
+    };
+
+    const GET = createSafeRoute()
+      .use(middleware1)
+      .use(middleware2)
+      .params(paramsSchema)
+      .handler((request, context) => {
+        const { id } = context.params;
+        const { user, permissions } = context.data;
+
+        return Response.json({ id, user, permissions }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: { id: '550e8400-e29b-41d4-a716-446655440000' } });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      user: { id: 'user-123' },
+      permissions: ['read', 'write'],
+    });
+  });
 });

--- a/src/routeHandlerBuilder.test.ts
+++ b/src/routeHandlerBuilder.test.ts
@@ -285,4 +285,35 @@ describe('combined validation', () => {
       permissions: ['read', 'write'],
     });
   });
+
+  it('should handle server errors using handleServerError method', async () => {
+    class CustomError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'CustomError';
+      }
+    }
+    const handleServerError = (error: Error) => {
+      if (error instanceof CustomError) {
+        return new Response(JSON.stringify({ message: error.name, details: error.message }), { status: 400 });
+      }
+
+      return new Response(JSON.stringify({ message: 'Something went wrong' }), { status: 400 });
+    };
+
+    const GET = createSafeRoute({
+      handleServerError,
+    })
+      .params(paramsSchema)
+      .handler(() => {
+        throw new CustomError('Test error');
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: { id: '550e8400-e29b-41d4-a716-446655440000' } });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({ message: 'CustomError', details: 'Test error' });
+  });
 });

--- a/src/routeHandlerBuilder.ts
+++ b/src/routeHandlerBuilder.ts
@@ -41,8 +41,8 @@ export class RouteHandlerBuilder<
    */
   params<T extends Schema>(schema: T): RouteHandlerBuilder<T, TQuery, TBody> {
     return new RouteHandlerBuilder<T, TQuery, TBody, TContext>({
+      ...this,
       config: { ...this.config, paramsSchema: schema },
-      middlewares: this.middlewares,
     });
   }
 
@@ -53,8 +53,8 @@ export class RouteHandlerBuilder<
    */
   query<T extends Schema>(schema: T): RouteHandlerBuilder<TParams, T, TBody> {
     return new RouteHandlerBuilder<TParams, T, TBody, TContext>({
+      ...this,
       config: { ...this.config, querySchema: schema },
-      middlewares: this.middlewares,
     });
   }
 
@@ -65,8 +65,8 @@ export class RouteHandlerBuilder<
    */
   body<T extends Schema>(schema: T): RouteHandlerBuilder<TParams, TQuery, T> {
     return new RouteHandlerBuilder<TParams, TQuery, T, TContext>({
+      ...this,
       config: { ...this.config, bodySchema: schema },
-      middlewares: this.middlewares,
     });
   }
 
@@ -79,7 +79,7 @@ export class RouteHandlerBuilder<
     middleware: Middleware<T>,
   ): RouteHandlerBuilder<TParams, TQuery, TBody, TContext & T> {
     return new RouteHandlerBuilder<TParams, TQuery, TBody, TContext & T>({
-      config: this.config,
+      ...this,
       middlewares: [...this.middlewares, middleware],
     });
   }
@@ -129,12 +129,13 @@ export class RouteHandlerBuilder<
         }
 
         // Call the handler function with the validated params, query, and body
-        return await handler(request, {
+        const result = await handler(request, {
           params: params as Infer<TParams>,
           query: query as Infer<TQuery>,
           body: body as Infer<TBody>,
           data: middlewareContext,
         });
+        return result;
       } catch (error) {
         if (this.handleServerError) {
           return this.handleServerError(error as Error);

--- a/src/routeHandlerBuilder.ts
+++ b/src/routeHandlerBuilder.ts
@@ -1,47 +1,87 @@
 import { Infer, Schema, validate } from '@typeschema/main';
 
-import { HandlerFunction, OriginalRouteHandler, RouteHandlerBuilderConfig } from './types';
+import { HandlerFunction, HandlerServerErrorFn, OriginalRouteHandler, RouteHandlerBuilderConfig } from './types';
+
+type Middleware<T = Record<string, unknown>> = (request: Request) => Promise<T>;
+
+interface RouteHandlerBuilderConstructorParams {
+  config?: RouteHandlerBuilderConfig;
+  middlewares?: Middleware[];
+  handleServerError?: HandlerServerErrorFn;
+}
 
 export class RouteHandlerBuilder<
   TParams extends Schema = Schema,
   TQuery extends Schema = Schema,
   TBody extends Schema = Schema,
+  TContext extends Record<string, unknown> = Record<string, unknown>,
 > {
-  // The config object that will be used to store the schemas
-  private config: RouteHandlerBuilderConfig = {
-    paramsSchema: undefined as unknown as TParams,
-    querySchema: undefined as unknown as TQuery,
-    bodySchema: undefined as unknown as TBody,
-  };
+  private config: RouteHandlerBuilderConfig;
+  private middlewares: Middleware[];
+  private handleServerError?: HandlerServerErrorFn;
+
+  constructor({
+    config = {
+      paramsSchema: undefined as unknown as TParams,
+      querySchema: undefined as unknown as TQuery,
+      bodySchema: undefined as unknown as TBody,
+    },
+    middlewares = [],
+    handleServerError,
+  }: RouteHandlerBuilderConstructorParams = {}) {
+    this.config = config;
+    this.middlewares = middlewares;
+    this.handleServerError = handleServerError;
+  }
 
   /**
    * Define the schema for the params
    * @param schema - The schema for the params
-   * @returns The instance of the RouteHandlerBuilder
+   * @returns A new instance of the RouteHandlerBuilder
    */
   params<T extends Schema>(schema: T): RouteHandlerBuilder<T, TQuery, TBody> {
-    this.config.paramsSchema = schema;
-    return this as unknown as RouteHandlerBuilder<T, TQuery, TBody>;
+    return new RouteHandlerBuilder<T, TQuery, TBody, TContext>({
+      config: { ...this.config, paramsSchema: schema },
+      middlewares: this.middlewares,
+    });
   }
 
   /**
    * Define the schema for the query
    * @param schema - The schema for the query
-   * @returns The instance of the RouteHandlerBuilder
+   * @returns A new instance of the RouteHandlerBuilder
    */
   query<T extends Schema>(schema: T): RouteHandlerBuilder<TParams, T, TBody> {
-    this.config.querySchema = schema;
-    return this as unknown as RouteHandlerBuilder<TParams, T, TBody>;
+    return new RouteHandlerBuilder<TParams, T, TBody, TContext>({
+      config: { ...this.config, querySchema: schema },
+      middlewares: this.middlewares,
+    });
   }
 
   /**
    * Define the schema for the body
    * @param schema - The schema for the body
-   * @returns The instance of the RouteHandlerBuilder
+   * @returns A new instance of the RouteHandlerBuilder
    */
   body<T extends Schema>(schema: T): RouteHandlerBuilder<TParams, TQuery, T> {
-    this.config.bodySchema = schema;
-    return this as unknown as RouteHandlerBuilder<TParams, TQuery, T>;
+    return new RouteHandlerBuilder<TParams, TQuery, T, TContext>({
+      config: { ...this.config, bodySchema: schema },
+      middlewares: this.middlewares,
+    });
+  }
+
+  /**
+   * Add a middleware to the route handler
+   * @param middleware - The middleware function to be executed
+   * @returns A new instance of the RouteHandlerBuilder
+   */
+  use<T extends Record<string, unknown>>(
+    middleware: Middleware<T>,
+  ): RouteHandlerBuilder<TParams, TQuery, TBody, TContext & T> {
+    return new RouteHandlerBuilder<TParams, TQuery, TBody, TContext & T>({
+      config: this.config,
+      middlewares: [...this.middlewares, middleware],
+    });
   }
 
   /**
@@ -49,47 +89,63 @@ export class RouteHandlerBuilder<
    * @param handler - The handler function that will be called when the route is hit
    * @returns The original route handler that Next.js expects with the validation logic
    */
-  handler(handler: HandlerFunction<Infer<TParams>, Infer<TQuery>, Infer<TBody>>): OriginalRouteHandler {
+  handler(handler: HandlerFunction<Infer<TParams>, Infer<TQuery>, Infer<TBody>, TContext>): OriginalRouteHandler {
     return async (request, context): Promise<Response> => {
-      const url = new URL(request.url);
-      const params = context?.params || {};
-      const query = Object.fromEntries(url.searchParams.entries());
-      const body = request.method !== 'GET' ? await request.json() : {};
+      try {
+        const url = new URL(request.url);
+        const params = context?.params || {};
+        const query = Object.fromEntries(url.searchParams.entries());
+        const body = request.method !== 'GET' ? await request.json() : {};
 
-      // Validate the params against the provided schema
-      if (this.config.paramsSchema) {
-        const paramsResult = await validate(this.config.paramsSchema, params);
-        if (!paramsResult.success) {
-          return new Response(JSON.stringify({ message: 'Invalid params', errors: paramsResult.issues }), {
-            status: 400,
-          });
+        // Validate the params against the provided schema
+        if (this.config.paramsSchema) {
+          const paramsResult = await validate(this.config.paramsSchema, params);
+          if (!paramsResult.success) {
+            throw new Error(JSON.stringify({ message: 'Invalid params', errors: paramsResult.issues }));
+          }
         }
-      }
 
-      // Validate the query against the provided schema
-      if (this.config.querySchema) {
-        const queryResult = await validate(this.config.querySchema, query);
-        if (!queryResult.success) {
-          return new Response(JSON.stringify({ message: 'Invalid query', errors: queryResult.issues }), {
-            status: 400,
-          });
+        // Validate the query against the provided schema
+        if (this.config.querySchema) {
+          const queryResult = await validate(this.config.querySchema, query);
+          if (!queryResult.success) {
+            throw new Error(JSON.stringify({ message: 'Invalid query', errors: queryResult.issues }));
+          }
         }
-      }
 
-      // Validate the body against the provided schema
-      if (this.config.bodySchema) {
-        const bodyResult = await validate(this.config.bodySchema, body);
-        if (!bodyResult.success) {
-          return new Response(JSON.stringify({ message: 'Invalid body', errors: bodyResult.issues }), { status: 400 });
+        // Validate the body against the provided schema
+        if (this.config.bodySchema) {
+          const bodyResult = await validate(this.config.bodySchema, body);
+          if (!bodyResult.success) {
+            throw new Error(JSON.stringify({ message: 'Invalid body', errors: bodyResult.issues }));
+          }
         }
-      }
 
-      // Call the handler function with the validated params, query, and body
-      return await handler(request, {
-        params: params as Infer<TParams>,
-        query: query as Infer<TQuery>,
-        body: body as Infer<TBody>,
-      });
+        // Execute middlewares and build context
+        let middlewareContext: TContext = {} as TContext;
+        for (const middleware of this.middlewares) {
+          const result = await middleware(request);
+          middlewareContext = { ...middlewareContext, ...result };
+        }
+
+        // Call the handler function with the validated params, query, and body
+        return await handler(request, {
+          params: params as Infer<TParams>,
+          query: query as Infer<TQuery>,
+          body: body as Infer<TBody>,
+          data: middlewareContext,
+        });
+      } catch (error) {
+        if (this.handleServerError) {
+          return this.handleServerError(error as Error);
+        }
+
+        if (error instanceof Error) {
+          return new Response(error.message, { status: 400 });
+        }
+
+        return new Response(JSON.stringify({ message: 'Internal server error' }), { status: 500 });
+      }
     };
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Schema } from '@typeschema/main';
 
-export type HandlerFunction<TParams, TQuery, TBody> = (
+export type HandlerFunction<TParams, TQuery, TBody, TContext> = (
   request: Request,
-  context: { params: TParams; query: TQuery; body: TBody },
+  context: { params: TParams; query: TQuery; body: TBody; data: TContext },
 ) => any;
 
 export interface RouteHandlerBuilderConfig {
@@ -13,3 +13,5 @@ export interface RouteHandlerBuilderConfig {
 }
 
 export type OriginalRouteHandler = (request: Request, context?: { params: Record<string, unknown> }) => any;
+
+export type HandlerServerErrorFn = (error: Error) => Response;


### PR DESCRIPTION
## Proposed Changes

- add `middleware` to createSafeRouter
- add tests for the `middleware`
- add `handleServerError` to have our own validation for our own error, seen on https://next-safe-action.dev/ that I use daily

I edit the code to always return a new instance of the `routeHandlerBuilder` to compose middleware.

Open to modification.
