### PR TITLE
Update params typing to support Next 15

### DIFF
--- a/src/routeHandlerBuilder.ts
+++ b/src/routeHandlerBuilder.ts
@@ -102,7 +102,7 @@ export class RouteHandlerBuilder<
     return async (request, context): Promise<Response> => {
       try {
         const url = new URL(request.url);
-        const params = context?.params || {};
+        const params = await(context?.params) || {};
         const query = Object.fromEntries(url.searchParams.entries());
         const body = request.method !== 'GET' ? await request.json() : {};
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,6 @@ export interface RouteHandlerBuilderConfig {
   bodySchema: Schema;
 }
 
-export type OriginalRouteHandler = (request: Request, context?: { params: Record<string, unknown> }) => any;
+export type OriginalRouteHandler = (request: Request, context?: { params: Promise<Record<string, unknown>> }) => any;
 
 export type HandlerServerErrorFn = (error: Error) => Response;


### PR DESCRIPTION
# Fixes
Next 15 introduced a change which makes route params asynchronous. These changes update the  type definitions for `params` to avoid an error where the params handler expected an object but received a Promise.

## Proposed Changes

- Update type definition for OriginalRouteHandler to make `params` async
- Await `params` in `routeHandlerBuilder.ts`
